### PR TITLE
SNP Coordinate Sorting Fix

### DIFF
--- a/CHEERS_computeEnrichment.py
+++ b/CHEERS_computeEnrichment.py
@@ -228,6 +228,11 @@ def calc_enrichment(unique_peaks, num_peaks, old_p_values):
 
     n = len(unique_peaks)
 
+    if n == 0:
+        p_values = pd.Series(np.full(observed_rank_means.shape, np.nan))
+        p_values.index = observed_rank_means.index
+        return observed_rank_means, p_values, num_peaks, n, np.nan, np.nan
+
     # Due to the use of Python 2, integer division returns an integer value
     # I'm casting the result to an integer to be consistent with the original CHEERS
     if old_p_values:
@@ -299,8 +304,8 @@ def main():
     observed_rank_means, p_values, N, n, mean_mean, mean_sd = calc_enrichment(unique_peaks, len(norm_data), args.old_p_values)
 
     # Write observed rank means and p-values to disk
-    p_values.to_csv(os.path.join(args.outdir, f'{args.trait}_disease_enrichment_pValues.txt'), sep='\t', header=False)
-    observed_rank_means.to_csv(os.path.join(args.outdir, f'{args.trait}_disease_enrichment_observedMeanRank.txt'), sep='\t', header=False)
+    p_values.to_csv(os.path.join(args.outdir, f'{args.trait}_disease_enrichment_pValues.txt'), sep='\t', header=False, na_rep='NA')
+    observed_rank_means.to_csv(os.path.join(args.outdir, f'{args.trait}_disease_enrichment_observedMeanRank.txt'), sep='\t', header=False, na_rep='NA')
 
     # Store the end time of the program
     end_time = time.time()

--- a/CHEERS_computeEnrichment.py
+++ b/CHEERS_computeEnrichment.py
@@ -119,6 +119,7 @@ def load_data(file_path):
     norm_matrix.start = norm_matrix.start.astype(int)
     norm_matrix.end = norm_matrix.end.astype(int)
     norm_matrix.sort_values(['chr', 'start', 'end'], ignore_index=True, inplace=True)
+    norm_matrix.reset_index(drop=True, inplace=True)
 
     return norm_matrix
 
@@ -154,6 +155,7 @@ def load_snp_list(file_path):
     snp_list.chr = snp_list.chr.astype(str)
     snp_list.pos = snp_list.pos.astype(int)
     snp_list.sort_values(['chr', 'pos'], inplace=True)
+    snp_list.reset_index(drop=True, inplace=True)
 
     return snp_list
 

--- a/CHEERS_computeEnrichment.py
+++ b/CHEERS_computeEnrichment.py
@@ -115,6 +115,9 @@ def load_data(file_path):
     '''
 
     norm_matrix = pd.read_csv(file_path, sep='\t')
+    norm_matrix.chr = norm_matrix.chr.astype(str)
+    norm_matrix.start = norm_matrix.start.astype(int)
+    norm_matrix.end = norm_matrix.end.astype(int)
     norm_matrix.sort_values(['chr', 'start', 'end'], ignore_index=True, inplace=True)
 
     return norm_matrix
@@ -147,6 +150,9 @@ def load_snp_list(file_path):
 
     snp_list = pd.read_csv(file_path, sep='\t', header=None)
     snp_list.columns = ['name', 'chr', 'pos']
+    snp_list.name = snp_list.name.astype(str)
+    snp_list.chr = snp_list.chr.astype(str)
+    snp_list.pos = snp_list.pos.astype(int)
     snp_list.sort_values(['chr', 'pos'], inplace=True)
 
     return snp_list

--- a/CHEERS_normalize.py
+++ b/CHEERS_normalize.py
@@ -126,6 +126,7 @@ def read_files(files):
     count_data.set_index(count_data.chr + '-' + count_data.start.map(str) + '-' + count_data.end.map(str), inplace=True)
    
     count_data.drop(['chr', 'start', 'end'], axis=1, inplace=True)
+    count_data = count_data.apply(pd.to_numeric)
 
     return count_data
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # CHEERS
  
 CHEERS (Chromatin Element Enrichment Ranking by Specificity) is a method to determine enrichment of annotations in GWAS significant loci. In addition to SNP-peak overlap, CHEERS takes into account peak properties as reflected by quantitative changes in read counts within peaks.
+
 Main code by Blagoje Soskic.
-LD calculation by Lara Bossini-Castillo, Python3.8 version  & test dataset courtesy of [Nikhil Milind](https://github.com/NMilind). 
+LD calculation by Lara Bossini-Castillo, Python 3.8 version and test dataset courtesy of [Nikhil Milind](https://github.com/NMilind). 
  
 ## Requirements
  
-This is a rewrite of CHEERS for **Python 3.8**. Please see the main branch python3 for a **Python2.7** version. It uses the following base modules:
+This is a rewrite of CHEERS for **Python 3.8**. Please see the `main` branch for a **Python 2.7** version. It uses the following base modules:
 
 1. `argparse`
 2. `functools`


### PR DESCRIPTION
Fixes #2.

If the SNPs were not sorted before applying `CHEERS_computeEnrichment.py`, the sort performed by `pandas` did not reset the index. This created a bug in the downstream peak overlap calling method. The fix resets the dataframe's index after sorting.